### PR TITLE
Extract Ouranos specific config out to a separate config file so it can be override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 
 # instantiated config
 env.local
+buildout/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - "${JENKINS_MASTER_PORT}:8080"
     volumes:
       - master_home:/var/jenkins_home
-      - ${JCASC_DIR}:/jcasc:ro
+      - ./buildout/jcasc_config:/jcasc:ro
     environment:
       - CASC_JENKINS_CONFIG=/jcasc/
       - SSH_PRIVATE_KEY=${SSH_PRIVATE_KEY}

--- a/env.local.example
+++ b/env.local.example
@@ -8,4 +8,14 @@ export JENKINS_ESGF_AUTH_PASSWORD=PASSWORD
 export JENKINS_ESGF_AUTH_TOKEN=TOKEN
 export SSH_PRIVATE_KEY="`cat ../my-cert/id_rsa_jenkins`"
 export JENKINS_SLAVE_SSH_PUBKEY="`cat ../my-cert/id_rsa_jenkins.pub`"
+
+# JCASC_DIR allows to have an entirely different Jenkins configuration than the
+# defaults in "./jcasc".
 export JCASC_DIR="./jcasc"
+
+# JCASC_EXTRA_DIRS allows for smaller config tweak, treating JCASC_DIR as
+# common basic configurations.  Useful to add more configs.  Use JCASC_DIR above
+# in case a complete config override is needed.
+# JCASC_EXTRA_DIRS supports space separed list: "/path/dir1 ./path/dir2 ./dir3",
+# latest dir has highest precedence.
+export JCASC_EXTRA_DIRS="./jcasc_extra_example"

--- a/env.local.example
+++ b/env.local.example
@@ -4,8 +4,8 @@ export JENKINS_ADMIN_PASSWD=admin
 export JENKINS_HTTP_PROTO=http
 export JENKINS_NUM_EXECUTORS_LOCAL=4
 export JENKINS_ESGF_AUTH_USERNAME=https://esgf-node.llnl.gov/esgf-idp/openid/FirstLast
-export JENKINS_ESGF_AUTH_PASSWORD=PASSWORD
-export JENKINS_ESGF_AUTH_TOKEN=TOKEN
+export JENKINS_ESGF_AUTH_PASSWORD=MY_ESGF_PASSWORD
+export JENKINS_ESGF_AUTH_TOKEN=MY_ESGF_TOKEN
 export SSH_PRIVATE_KEY="`cat ../my-cert/id_rsa_jenkins`"
 export JENKINS_SLAVE_SSH_PUBKEY="`cat ../my-cert/id_rsa_jenkins.pub`"
 

--- a/jcasc/jenkins.yaml
+++ b/jcasc/jenkins.yaml
@@ -6,9 +6,6 @@ jenkins:
   agentProtocols:
   - "JNLP4-connect"
   - "Ping"
-  authorizationStrategy:
-    loggedInUsersCanDoAnything:
-      allowAnonymousRead: true
   crumbIssuer:
     standard:
       excludeClientIPFromCrumb: false
@@ -40,8 +37,6 @@ jenkins:
   scmCheckoutRetryCount: 0
   securityRealm:
     local:
-      allowsSignup: true
-      enableCaptcha: false
       users:
       - id: "admin"
         password: ${ADMIN_PASSWD}  # Env var
@@ -61,26 +56,12 @@ credentials:
               privateKey: ${SSH_PRIVATE_KEY}  # Load from Environment Variable
           scope: SYSTEM
           username: "jenkins"
-      - usernamePassword:
-          description: "ESGF authentication username password"
-          id: "esgf_auth"
-          password: ${ESGF_AUTH_PASSWORD}
-          scope: GLOBAL
-          username: ${ESGF_AUTH_USERNAME}
-      - string:
-          description: "ESGF authentication token"
-          id: "esgf_auth_token"
-          scope: GLOBAL
-          secret: ${ESGF_AUTH_TOKEN}
 security:
   remotingCLI:
     enabled: false
 unclassified:
   location:
-    adminAddress: "Jenkins <noreply@ouranos.ca>"  # from field for mail from Jenkins
     url: "${HTTP_PROTO}://${HOSTNAME}:${HOSTPORT}/"  # Env var
-  extendedEmailPublisher:
-    allowUnregisteredEnabled: true
 tool:
   git:
     installations:

--- a/jcasc_extra_example/jenkins_extra.yaml
+++ b/jcasc_extra_example/jenkins_extra.yaml
@@ -1,0 +1,30 @@
+jenkins:
+  authorizationStrategy:
+    loggedInUsersCanDoAnything:
+      allowAnonymousRead: true
+  securityRealm:
+    local:
+      allowsSignup: true
+      enableCaptcha: false
+credentials:
+  system:
+    domainCredentials:
+    - credentials:
+      - usernamePassword:
+          description: "ESGF authentication username password"
+          id: "esgf_auth"
+          password: ${ESGF_AUTH_PASSWORD}
+          scope: GLOBAL
+          username: ${ESGF_AUTH_USERNAME}
+      - string:
+          description: "ESGF authentication token"
+          id: "esgf_auth_token"
+          scope: GLOBAL
+          secret: ${ESGF_AUTH_TOKEN}
+unclassified:
+  location:
+    adminAddress: "Jenkins <noreply@ouranos.ca>"  # from field for mail from Jenkins
+  extendedEmailPublisher:
+    allowUnregisteredEnabled: true
+
+# vi: tabstop=8 expandtab shiftwidth=2 softtabstop=2

--- a/jenkins-compose.sh
+++ b/jenkins-compose.sh
@@ -33,19 +33,21 @@ then
   exit 1
 fi
 
-# create CASC_JENKINS_CONFIG
-CASC_JENKINS_CONFIG=buildout/jcasc_config
-rm -vrf $CASC_JENKINS_CONFIG
-mkdir -p $CASC_JENKINS_CONFIG
-cp -v $JCASC_DIR/*.yaml $CASC_JENKINS_CONFIG/
-for adir in $JCASC_EXTRA_DIRS; do
-  # latest dir has highest precedence
-  if [ -d "$adir" ]; then
-    cp -v $adir/*.yaml $CASC_JENKINS_CONFIG/
-  else
-    echo "${YELLOW}Warn${NORMAL}: JCASC extra dir '$adir' do not exist."
-  fi
-done
+if [[ $1 == "up" || $1 == "restart" ]]; then
+  # create CASC_JENKINS_CONFIG
+  CASC_JENKINS_CONFIG=buildout/jcasc_config
+  rm -vrf $CASC_JENKINS_CONFIG
+  mkdir -p $CASC_JENKINS_CONFIG
+  cp -v $JCASC_DIR/*.yaml $CASC_JENKINS_CONFIG/
+  for adir in $JCASC_EXTRA_DIRS; do
+    # latest dir has highest precedence
+    if [ -d "$adir" ]; then
+      cp -v $adir/*.yaml $CASC_JENKINS_CONFIG/
+    else
+      echo "${YELLOW}Warn${NORMAL}: JCASC extra dir '$adir' do not exist."
+    fi
+  done
+fi
 
 # we apply all the templates
 #find . -name '*.template' -print0 |

--- a/jenkins-compose.sh
+++ b/jenkins-compose.sh
@@ -5,7 +5,7 @@ RED=$(tput setaf 1)
 NORMAL=$(tput sgr0)
 
 # list of all variables to be substituted in templates
-VARS='$JENKINS_MASTER_PORT $SSH_PRIVATE_KEY $JENKINS_ADMIN_PASSWD $JENKINS_HTTP_PROTO $JENKINS_HOSTNAME $JENKINS_SLAVE_SSH_PUBKEY $JENKINS_NUM_EXECUTORS_LOCAL'
+VARS='$JENKINS_MASTER_PORT $SSH_PRIVATE_KEY $JENKINS_ADMIN_PASSWD $JENKINS_HTTP_PROTO $JENKINS_HOSTNAME $JENKINS_SLAVE_SSH_PUBKEY $JENKINS_NUM_EXECUTORS_LOCAL $JCASC_DIR'
 
 export DOCKER_GROUP_ON_HOST="`getent group |grep docker: | awk -F: '{print $3}'`"
 
@@ -32,6 +32,20 @@ then
   echo "Error, this script must be ran from the folder containing the docker-compose.yml file"
   exit 1
 fi
+
+# create CASC_JENKINS_CONFIG
+CASC_JENKINS_CONFIG=buildout/jcasc_config
+rm -vrf $CASC_JENKINS_CONFIG
+mkdir -p $CASC_JENKINS_CONFIG
+cp -v $JCASC_DIR/*.yaml $CASC_JENKINS_CONFIG/
+for adir in $JCASC_EXTRA_DIRS; do
+  # latest dir has highest precedence
+  if [ -d "$adir" ]; then
+    cp -v $adir/*.yaml $CASC_JENKINS_CONFIG/
+  else
+    echo "${YELLOW}Warn${NORMAL}: JCASC extra dir '$adir' do not exist."
+  fi
+done
 
 # we apply all the templates
 #find . -name '*.template' -print0 |


### PR DESCRIPTION
@huard: We now have a `jenkins-private-config` repo that can override the example file `jcasc_extra_example/jenkins_extra.yaml`.

That example is there so Jenkins has all the minimal config to start up so we can easily demo the features of this repo.  I actually left the noreply@ouranos.ca in the example because that's not anything confidential and that email do not even exist for real.

This `jenkins-config` repo is now public.