### PR TITLE
Migrate config for jenkins 2.190.3 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,14 @@ those variables are from your customized `env.local` file.
 docker-compose use-cases and command-line options are supported.
 
 Upgrade instructions
-```
+```shell
 ./jenkins-compose.sh down -v  # only delete anonymous data volume
 git pull
 # update env.local with new variables from env.local.example if needed
 scripts/backup-jenkins-master.sh  # backup to /tmp
 ./jenkins-compose.sh up -d
+# multibranch pipeline jobs might need a manual "Scan Multibranch Pipeline Now"
+# to keep Stage View intact
 ```
 
 See

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Upgrade instructions
 ```
 ./jenkins-compose.sh down -v  # only delete anonymous data volume
 git pull
+# update env.local with new variables from env.local.example if needed
+scripts/backup-jenkins-master.sh  # backup to /tmp
 ./jenkins-compose.sh up -d
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   master:
-    image: pavics/jenkins-master:2.190.2.191119
+    image: pavics/jenkins-master:2.190.3.191129
     hostname: jenkins_master
     ports:
       - "${JENKINS_MASTER_PORT}:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   master:
-    image: pavics/jenkins-master:2.150.3.190311
+    image: pavics/jenkins-master:2.190.2.191119
     hostname: jenkins_master
     ports:
       - "${JENKINS_MASTER_PORT}:8080"

--- a/jcasc/jenkins.yaml
+++ b/jcasc/jenkins.yaml
@@ -1,7 +1,3 @@
-plugins:
-  sites:
-  - id: "default"
-    url: "https://updates.jenkins.io/update-center.json"
 jenkins:
   agentProtocols:
   - "JNLP4-connect"
@@ -41,6 +37,10 @@ jenkins:
       - id: "admin"
         password: ${ADMIN_PASSWD}  # Env var
   slaveAgentPort: 50000
+  updateCenter:
+    sites:
+    - id: "default"
+      url: "https://updates.jenkins.io/update-center.json"
   views:
   - all:
       name: "all"

--- a/jcasc/jenkins.yaml
+++ b/jcasc/jenkins.yaml
@@ -6,7 +6,9 @@ jenkins:
     standard:
       excludeClientIPFromCrumb: false
   disableRememberMe: false
+  markupFormatter: "plainText"
   mode: NORMAL
+  myViewsTabBar: "standard"
   nodes:
   - permanent:
       labelString: "linux docker"
@@ -29,7 +31,10 @@ jenkins:
   primaryView:
     all:
       name: "all"
+  projectNamingStrategy: "standard"
   quietPeriod: 5
+  remotingSecurity:
+    enabled: true
   scmCheckoutRetryCount: 0
   securityRealm:
     local:
@@ -44,6 +49,18 @@ jenkins:
   views:
   - all:
       name: "all"
+  viewsTabBar: "standard"
+security:
+  apiToken:
+    creationOfLegacyTokenEnabled: false
+    tokenGenerationOnCreationEnabled: false
+    usageStatisticsEnabled: true
+  downloadSettings:
+    useBrowser: false
+  globalJobDslSecurityConfiguration:
+    useScriptSecurity: true
+  sSHD:
+    port: -1
 credentials:
   system:
     domainCredentials:

--- a/jcasc/jenkins.yaml
+++ b/jcasc/jenkins.yaml
@@ -1,3 +1,15 @@
+credentials:
+  system:
+    domainCredentials:
+    - credentials:
+      - basicSSHUserPrivateKey:
+          description: "private id_rsa_jenkins to connect to worker"
+          id: "id_rsa_jenkins"
+          privateKeySource:
+            directEntry:
+              privateKey: ${SSH_PRIVATE_KEY}  # Load from Environment Variable
+          scope: SYSTEM
+          username: "jenkins"
 jenkins:
   agentProtocols:
   - "JNLP4-connect"
@@ -13,7 +25,7 @@ jenkins:
   - permanent:
       labelString: "linux docker"
       launcher:
-        sSHLauncher:
+        ssh:
           credentialsId: "id_rsa_jenkins"
           host: "slave"
           launchTimeoutSeconds: 210
@@ -61,18 +73,6 @@ security:
     useScriptSecurity: true
   sSHD:
     port: -1
-credentials:
-  system:
-    domainCredentials:
-    - credentials:
-      - basicSSHUserPrivateKey:
-          description: "private id_rsa_jenkins to connect to worker"
-          id: "id_rsa_jenkins"
-          privateKeySource:
-            directEntry:
-              privateKey: ${SSH_PRIVATE_KEY}  # Load from Environment Variable
-          scope: SYSTEM
-          username: "jenkins"
 unclassified:
   location:
     url: "${HTTP_PROTO}://${HOSTNAME}:${HOSTPORT}/"  # Env var

--- a/jcasc/jenkins.yaml
+++ b/jcasc/jenkins.yaml
@@ -56,9 +56,6 @@ credentials:
               privateKey: ${SSH_PRIVATE_KEY}  # Load from Environment Variable
           scope: SYSTEM
           username: "jenkins"
-security:
-  remotingCLI:
-    enabled: false
 unclassified:
   location:
     url: "${HTTP_PROTO}://${HOSTNAME}:${HOSTPORT}/"  # Env var

--- a/jcasc/jobs.yaml
+++ b/jcasc/jobs.yaml
@@ -3,6 +3,7 @@ jobs:
       multibranchPipelineJob('PAVICS-e2e-workflow-tests') {
         branchSources {
           git {
+            id = 'PAVICS-e2e-workflow-tests'
             remote('https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests.git')
           }
         }

--- a/scripts/backup-datavolume.sh
+++ b/scripts/backup-datavolume.sh
@@ -1,0 +1,17 @@
+#!/bin/sh -x
+# Backup DATA_VOL_NAME to BACKUP_OUT_DIR/DATA_VOL_NAME.tgz
+
+DATA_VOL_NAME="$1"; shift
+BACKUP_OUT_DIR="$1"; shift
+
+echo "Will create $BACKUP_OUT_DIR/$DATA_VOL_NAME.tgz"
+
+docker run --rm \
+  --name backup_data_vol_$DATA_VOL_NAME \
+  -u root \
+  -v $BACKUP_OUT_DIR:/backups \
+  -v $DATA_VOL_NAME:/data_vol_to_backup:ro \
+  bash \
+  tar czvf /backups/$DATA_VOL_NAME.tgz -C /data_vol_to_backup .
+
+# vi: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/scripts/backup-jenkins-master.sh
+++ b/scripts/backup-jenkins-master.sh
@@ -1,0 +1,21 @@
+#!/bin/sh -x
+# Backup to /tmp/jenkins_master_home_$JENKINS_MASTER_PORT.tgz with default values.
+
+cd `dirname "$0"`/..
+. ./env.local
+
+if [ -z "$BACKUP_OUT_DIR" ]; then
+    BACKUP_OUT_DIR=/tmp
+fi
+
+if [ -z "$DOCKER_USER_PERSISTENCE_VOLUME" ]; then
+    # dupe with jenkins-compose.sh
+    DOCKER_USER_PERSISTENCE_VOLUME=jenkins_master_home_$JENKINS_MASTER_PORT
+fi
+
+scripts/backup-datavolume.sh "$DOCKER_USER_PERSISTENCE_VOLUME" "$BACKUP_OUT_DIR"
+
+ls -lh $BACKUP_OUT_DIR/$DOCKER_USER_PERSISTENCE_VOLUME.tgz
+
+
+# vi: tabstop=8 expandtab shiftwidth=4 softtabstop=4


### PR DESCRIPTION
We should really keep up with upgrade.

This has been a harder than expected upgrade because we waited 8 month with 3 LTS releases in between.

Quite a few configs changed names or places or just do not exist anymore, see each commit message.  It felt like a mini Magpie upgrade.

If you noticed the jenkins slave has not been updated.  The new master is unable to connect to the new slave so I left the old slave there.  This will be for another time.