### PR TITLE
jenkins-slave: work-around to apply the new entrypoint to the existing old slave

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
     hostname: jenkins_slave
     volumes:
       - slave_home:/home/jenkins
+      - ./jenkins-slave/entrypoint_slave:/entrypoint:ro
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
       - JENKINS_SLAVE_SSH_PUBKEY=$JENKINS_SLAVE_SSH_PUBKEY

--- a/jenkins-slave/entrypoint_slave
+++ b/jenkins-slave/entrypoint_slave
@@ -1,0 +1,32 @@
+#!/bin/sh -x
+
+# From https://raw.githubusercontent.com/Ouranosinc/jenkins-ssh-slave/3d40413616c05fc98f92269d22636dd085c83d03/entrypoint_slave
+#
+# To override the entrypoint in the existing slave.
+#
+# New build of the slave will already have this new entrypoint but unable to
+# use new build for the slave with new master.  New master unable to connect to
+# new slave over ssh.
+#
+# This is just a work-around until we can get the new slave working with the
+# new master.
+
+if [ -n "$DOCKER_GROUP_ON_HOST" ]; then
+
+    # create a new group with the same id as the docker group on the original
+    # host
+    addgroup --gid $DOCKER_GROUP_ON_HOST docker_from_host
+
+    # in the case when the docker group gid is the same on the host and in the
+    # container, the previous command will fail, because the group already exists.
+    # so we get the docker group name from the gid instead.
+    docker_group_name=$(cat /etc/group | grep :$DOCKER_GROUP_ON_HOST: | cut -d ':' -f1)
+
+    # add user jenkins, that will run the slave, to that new group so user
+    # jenkins can launch docker containers using the docker daemon on the
+    # original host
+    usermod -G "$docker_group_name" -a jenkins
+fi
+
+# finally call the same entrypoint as the original base image
+/usr/local/bin/setup-sshd "$@"


### PR DESCRIPTION
To fix the problem when the docker group id is the same on the host and
inside the slave container.

@davidcaron this is a work-around so you can smootly deploy Jenkins on your side.  I do not have time to investigate the ssh connection problem between the master and the new slave right now but do not want to keep you waiting.