### PR TITLE
master: rollback to previous working version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   master:
-    image: pavics/jenkins-master:2.249.1.201009
+    image: pavics/jenkins-master:2.190.3.191209
     hostname: jenkins_master
     ports:
       - "${JENKINS_MASTER_PORT}:8080"


### PR DESCRIPTION
I spinned up a Jenkins for @mishaschwartz and I saw the error below.  The simplest solution is to revert to the previous working version.

@matprov have you tried to spin up a fresh Jenkins lately?

Current version have this error directly in the WebUI on startup, breaking Jenkins:
```
io.jenkins.plugins.casc.ConfiguratorException: Invalid configuration elements for type class jenkins.model.GlobalConfigurationCategory$Unclassified : extendedEmailPublisher.
Available attributes : administrativeMonitorsConfiguration, ansiColorBuildWrapper, artifactManager, buildDiscarders, buildStepOperation, casCGlobalConfig, defaultFolderConfiguration, defaultView, email-ext, envInjectNodeProperty, envVarsFilter, fingerprints, ghprbPullRequestMerge, ghprbTrigger, gitHubConfiguration, gitHubPluginConfig, gitSCM, githubPullRequests, globalDefaultFlowDurabilityLevel, globalLibraries, junitTestResultStorage, location, lockableResourcesManager, mailer, masterBuild, myView, nodeProperties, pipeline-model-docker, plugin, pollSCM, projectNamingStrategy, quietPeriod, resourceRoot, scmRetryCount, shell, slackNotifier, subversionSCM, timestamper, usageStatistics, viewsTabBar
	at io.jenkins.plugins.casc.BaseConfigurator.handleUnknown(BaseConfigurator.java:376)
	at io.jenkins.plugins.casc.BaseConfigurator.configure(BaseConfigurator.java:365)
	at io.jenkins.plugins.casc.BaseConfigurator.check(BaseConfigurator.java:287)
	at io.jenkins.plugins.casc.ConfigurationAsCode.lambda$checkWith$8(ConfigurationAsCode.java:755)
	at io.jenkins.plugins.casc.ConfigurationAsCode.invokeWith(ConfigurationAsCode.java:691)
Caused: io.jenkins.plugins.casc.ConfiguratorException: unclassified: error configuring 'unclassified' with class io.jenkins.plugins.casc.impl.configurators.GlobalConfigurationCategoryConfigurator configurator
	at io.jenkins.plugins.casc.ConfigurationAsCode.invokeWith(ConfigurationAsCode.java:697)
	at io.jenkins.plugins.casc.ConfigurationAsCode.checkWith(ConfigurationAsCode.java:755)
	at io.jenkins.plugins.casc.ConfigurationAsCode.configureWith(ConfigurationAsCode.java:740)
	at io.jenkins.plugins.casc.ConfigurationAsCode.configureWith(ConfigurationAsCode.java:616)
	at io.jenkins.plugins.casc.ConfigurationAsCode.configure(ConfigurationAsCode.java:298)
	at io.jenkins.plugins.casc.ConfigurationAsCode.init(ConfigurationAsCode.java:290)
Caused: java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at hudson.init.TaskMethodFinder.invoke(TaskMethodFinder.java:104)
Caused: java.lang.Error
	at hudson.init.TaskMethodFinder.invoke(TaskMethodFinder.java:110)
	at hudson.init.TaskMethodFinder$TaskImpl.run(TaskMethodFinder.java:175)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:296)
	at jenkins.model.Jenkins$5.runTask(Jenkins.java:1131)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:214)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:59)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused: org.jvnet.hudson.reactor.ReactorException
	at org.jvnet.hudson.reactor.Reactor.execute(Reactor.java:282)
	at jenkins.InitReactorRunner.run(InitReactorRunner.java:50)
	at jenkins.model.Jenkins.executeReactor(Jenkins.java:1164)
	at jenkins.model.Jenkins.<init>(Jenkins.java:964)
	at hudson.model.Hudson.<init>(Hudson.java:85)
	at hudson.model.Hudson.<init>(Hudson.java:81)
	at hudson.WebAppMain$3.run(WebAppMain.java:282)
Caused: hudson.util.HudsonFailedToLoad
	at hudson.WebAppMain$3.run(WebAppMain.java:299)
```